### PR TITLE
Add retry on 503

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: setup.py requirements.txt
+
+DIST_BASENAME := $(shell poetry version | tr ' ' '-')
+
+build: setup.py requirements.txt
+
+setup.py:
+	poetry build && \
+	tar --strip-components=1 -xvf dist/$(DIST_BASENAME).tar.gz '*/setup.py'
+
+requirements.txt:
+	poetry export --without-hashes > requirements.txt
+
+clean:
+	rm -rf .pytest_cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ packages = [
 ]
 license = "Apache-2.0"
 readme = "README.md"
-version = "0.3.0"
+version = "0.3.1"
 description = "AsyncIO client for Extreme Cloud IQ"
 authors = ["Jeremy Schulman <jeremy.schulman@mlb.com>"]
 repository = "https://github.com/jeremyschulman/aio-xiq"


### PR DESCRIPTION
In some cases the XIQ SaaS returns a 503; perhaps when it should be returning a 429 (for rate-limit).
Adding a retry in the client to handle this case.